### PR TITLE
Support non-integer primary keys

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -112,20 +112,12 @@ class SortableAdmin(ModelAdmin):
         """
 
         if request.is_ajax() and request.method == 'POST':
-            try:
-                indexes = request.POST.get('indexes', []).split(',')
-                klass = ContentType.objects.get(id=model_type_id).model_class()
-                objects_dict = dict([(obj.pk, obj) for obj in klass.objects.filter(pk__in=indexes)])
-                min_index = min(objects_dict.values(), key=lambda x: getattr(x, 'order'))
-                min_index = getattr(min_index, 'order') or 0
-                for index in indexes:
-                    obj = objects_dict[int(index)]
-                    setattr(obj, 'order', min_index)
-                    obj.save()
-                    min_index += 1
-                response = {'objects_sorted' : True}
-            except (IndexError, klass.DoesNotExist, AttributeError):
-                pass
+            klass = ContentType.objects.get(id=model_type_id).model_class()
+            for order, pk in enumerate(request.POST['indexes'].split(',')):
+                obj = klass.objects.get(pk=pk)
+                obj.order = order
+                obj.save()
+            response = {'objects_sorted' : True}
         else:
             response = {'objects_sorted' : False}
         return HttpResponse(json.dumps(response, ensure_ascii=False),


### PR DESCRIPTION
The current do-sorting view assumes the model's primary key is an integer. This patch fixes that assumption, at the cost of some efficiency. You can switch it back to the dict-cache method it was using, but I did it the succinct way since sorting is a relatively rare operation for my app. I didn't check for this bug in other parts of the code.
