### PR TITLE
Make inline hint translatable

### DIFF
--- a/adminsortable/templates/adminsortable/edit_inline/stacked.html
+++ b/adminsortable/templates/adminsortable/edit_inline/stacked.html
@@ -1,7 +1,7 @@
 {% load i18n admin_modify adminsortable_tags %}
 {% load static from staticfiles %}
 <div class="inline-group" id="{{ inline_admin_formset.formset.prefix }}-group">
-  <h2>{{ inline_admin_formset.opts.verbose_name_plural|title }} {% if inline_admin_formset.formset.initial_form_count > 1 %} - drag and drop to change order{% endif %}</h2>
+  <h2>{{ inline_admin_formset.opts.verbose_name_plural|title }} {% if inline_admin_formset.formset.initial_form_count > 1 %} - {% trans "drag and drop to change order" %}{% endif %}</h2>
 {{ inline_admin_formset.formset.management_form }}
 {{ inline_admin_formset.formset.non_form_errors }}
 

--- a/adminsortable/templates/adminsortable/edit_inline/tabular.html
+++ b/adminsortable/templates/adminsortable/edit_inline/tabular.html
@@ -4,7 +4,7 @@
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
 {{ inline_admin_formset.formset.management_form }}
 <fieldset class="module">
-   <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }} {% if inline_admin_formset.formset.initial_form_count > 1 %} - drag and drop to change order{% endif %}</h2>
+   <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }} {% if inline_admin_formset.formset.initial_form_count > 1 %} - {% trans "drag and drop to change order" %}{% endif %}</h2>
    {{ inline_admin_formset.formset.non_form_errors }}
    <table>
      <thead><tr>


### PR DESCRIPTION
It would be nice if these strings are translatable, too.
