### PR TITLE
README: Forgotten little comma causing lots of havoc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Example:
                     'adminsortable/js/admin.sortable.tabular.inlines.js',
                 )
             css = {
-                'screen': ('adminsortable/css/admin.sortable.inline.css'),
+                'screen': ('adminsortable/css/admin.sortable.inline.css', ),
             }
 
 


### PR DESCRIPTION
In the known issues section in the README, you forgot a comma. Causing what should have been a tuple to be read like a string.
