### PR TITLE
Replace deprecated mimetype with content_type

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -246,7 +246,7 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
                 pass
 
         return HttpResponse(json.dumps(response, ensure_ascii=False),
-            mimetype='application/json')
+            content_type='application/json')
 
 
 class SortableInlineBase(SortableAdminBase, InlineModelAdmin):


### PR DESCRIPTION
Passing `mimetype` to an HttpResponse object is deprecated
since Django 1.5 and will throw an error in Django 1.7.
`content_type` is supported since Django 1.0.
