### PR TITLE
enable js correctly for generic inlines

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -189,9 +189,9 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
         })
 
         for klass in self.inlines:
-            if issubclass(klass, SortableTabularInline):
+            if issubclass(klass, SortableTabularInline) or issubclass(klass, SortableGenericTabularInline):
                 self.has_sortable_tabular_inlines = True
-            if issubclass(klass, SortableStackedInline):
+            if issubclass(klass, SortableStackedInline) or issubclass(klass, SortableGenericStackedInline):
                 self.has_sortable_stacked_inlines = True
 
         if self.has_sortable_tabular_inlines or \


### PR DESCRIPTION
If a SortableAdmin only has GenericInlines the javascript is not correctly loaded and it's not possible to sort the models by drag&dropping them.

This fixes that issue.
