### PR TITLE
Fix formatting string for Python 2.6

### DIFF
--- a/adminsortable/__init__.py
+++ b/adminsortable/__init__.py
@@ -3,12 +3,12 @@ DEV_N = None
 
 
 def get_version():
-    version = '{}.{}'.format(VERSION[0], VERSION[1])
+    version = '{0}.{1}'.format(VERSION[0], VERSION[1])
     if VERSION[2]:
-        version = '{}.{}'.format(version, VERSION[2])
+        version = '{0}.{1}'.format(version, VERSION[2])
     try:
         if VERSION[3]:
-            version = '{}.{}'.format(version, VERSION[3])
+            version = '{0}.{1}'.format(version, VERSION[3])
     except IndexError:
         pass
     return version


### PR DESCRIPTION
Not sure if anything else is broken in Python 2.6, the package just won't install currently.
