### PR TITLE
fix slow get_is_sortable when using with inline admins

### DIFF
--- a/adminsortable/utils.py
+++ b/adminsortable/utils.py
@@ -6,11 +6,13 @@ def check_inheritance(obj):
 
 
 def get_is_sortable(objects):
-    if objects:
-        if check_inheritance(objects[0]):
-            if objects.count() > 1:
-                return True
-    return False
+    if objects.count() < 2:
+        return False
+
+    if not check_inheritance(objects[:1][0]):
+        return False
+
+    return True
 
 
 def is_self_referential(cls):


### PR DESCRIPTION
the first `if` call did execute the whole `select` query with (perhaps)
millions of records in them, even though the only result needed here
is one record.

The acually used queryset later will be filtered by the parent-model.