### PR TITLE
Variable jQuery location for Django version 1.9 and above

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -108,6 +108,9 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
             has_perm = request.user.has_perm('{0}.{1}'.format(opts.app_label,
                 opts.get_change_permission()))
 
+        jquery_lib_path = 'admin/js/jquery.js' if VERSION < (1, 9) \
+            else 'admin/js/vendor/jquery/jquery.js'
+
         # get sort group index from querystring if present
         sort_filter_index = request.GET.get('sort_filter')
 
@@ -182,7 +185,8 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
             'group_expression': sortable_by_expression,
             'sortable_by_class': sortable_by_class,
             'sortable_by_class_is_sortable': sortable_by_class_is_sortable,
-            'sortable_by_class_display_name': sortable_by_class_display_name
+            'sortable_by_class_display_name': sortable_by_class_display_name,
+            'jquery_lib_path': jquery_lib_path
         }
         return render(request, self.sortable_change_list_template, context)
 

--- a/adminsortable/templates/adminsortable/change_list.html
+++ b/adminsortable/templates/adminsortable/change_list.html
@@ -9,7 +9,7 @@
 
 {% block extrahead %}
 	{{ block.super }}
-    <script src="{% static 'admin/js/jquery.js' %}"></script>
+    <script src="{% static jquery_lib_path %}"></script>
     <script src="{% static 'admin/js/jquery.init.js' %}"></script>
 	<script src="{% static 'adminsortable/js/jquery-ui-django-admin.min.js' %}"></script>
     <script src="{% static 'adminsortable/js/jquery.django-csrf.js' %}"></script>


### PR DESCRIPTION
On Django 1.9 jQuery location changes from 'admin/js/jquery.js' to 'admin/js/vendor/jquery/jquery.js', so a mechanism for loading it from one place or another is needed. Another possibility would have been passing the Django version the context and let the template and decide which one should load there