### PR TITLE
Document incompatibility with CSRF_COOKIE_HTTPONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Download django-admin-sortable from [source](https://github.com/iambrandontaylor
 ## Configuration
 1. Add `adminsortable` to your `INSTALLED_APPS`.
 2. Ensure `django.core.context_processors.static` is in your `TEMPLATE_CONTEXT_PROCESSORS`.
+3. Ensure that `CSRF_COOKIE_HTTPONLY` has not been set to `True`, as
+django-admin-sortable is currently incompatible with that setting.
 
 
 ### Static Media

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,8 @@ Configuration
 1. Add ``adminsortable`` to your ``INSTALLED_APPS``.
 2. Ensure ``django.core.context_processors.static`` is in your
    ``TEMPLATE_CONTEXT_PROCESSORS``.
+3. Ensure that ``CSRF_COOKIE_HTTPONLY`` has not been set to ``True``, as
+   django-admin-sortable is currently incompatible with that setting.
 
 Static Media
 ~~~~~~~~~~~~


### PR DESCRIPTION
`jquery.django-csrf.js` relies on `csrftoken` cookie being accessible
through `document.cookie`, so we need to document that or fix it.