### PR TITLE
Fix inline sorting after support for custom CSRF_COOKIE_NAME

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -66,7 +66,7 @@ class SortableAdminBase(object):
         extra_context.update({
             'change_list_template_extends': self.change_list_template_extends,
             'sorting_filters': [sort_filter[0] for sort_filter
-                in getattr(self.model, 'sorting_filters', [])]
+                in getattr(self.model, 'sorting_filters', [])],
         })
         return super(SortableAdminBase, self).changelist_view(request,
             extra_context=extra_context)
@@ -238,7 +238,8 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
             extra_context = {}
 
         extra_context.update({
-            'change_form_template_extends': self.change_form_template_extends
+            'change_form_template_extends': self.change_form_template_extends,
+            'csrf_cookie_name': getattr(settings, 'CSRF_COOKIE_NAME', 'csrftoken')
         })
 
         for klass in self.inlines:

--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -66,7 +66,7 @@ class SortableAdminBase(object):
         extra_context.update({
             'change_list_template_extends': self.change_list_template_extends,
             'sorting_filters': [sort_filter[0] for sort_filter
-                in getattr(self.model, 'sorting_filters', [])],
+                in getattr(self.model, 'sorting_filters', [])]
         })
         return super(SortableAdminBase, self).changelist_view(request,
             extra_context=extra_context)


### PR DESCRIPTION
Pass the csrf_cookie_name into the change_view so that sorting on inlines works again