### PR TITLE
js: fix indexes finding for tabular inlines

### DIFF
--- a/adminsortable/static/adminsortable/js/admin.sortable.tabular.inlines.js
+++ b/adminsortable/static/adminsortable/js/admin.sortable.tabular.inlines.js
@@ -27,7 +27,7 @@
                     var indexes = [];
                     ui.item.parent().children('tr').each(function(i)
                     {
-                        var index_value = $(this).find('.original :hidden:first').val();
+                        var index_value = $(this).find('.original').find(':input').first().val();
                         if (index_value !== '' && index_value !== undefined) {
                             indexes.push(index_value);
                         }


### PR DESCRIPTION
js: fix indexes finding for tabular inlines

Not sure with but unless I change the code the line 30 finds the "i" tags instead of the input.