### PR TITLE
Fix UI when djangocms-admin-style is used

### DIFF
--- a/adminsortable/static/adminsortable/js/admin.sortable.js
+++ b/adminsortable/static/adminsortable/js/admin.sortable.js
@@ -24,7 +24,7 @@
                     {
                         // set icons based on position
                         lineItems.each(function(index, element) {
-                            var icon = $(element).find('> a .fa');
+                            var icon = $(element).find('a.admin_sorting_url .fa');
                             icon.removeClass('fa-sort-desc fa-sort-asc fa-sort');
 
                             if (index === 0) {

--- a/adminsortable/templates/adminsortable/shared/object_rep.html
+++ b/adminsortable/templates/adminsortable/shared/object_rep.html
@@ -2,5 +2,5 @@
 
 <form>
     <input name="pk" type="hidden" value="{{ object.pk }}" />
+    <a href="{% url 'admin:admin_do_sorting' object.model_type_id %}" class="admin_sorting_url"><i class="fa fa-{% if forloop.first %}sort-desc{% elif forloop.last %}sort-asc{% else %}sort{% endif %}"></i> {{ object }}</a>
 </form>
-<a href="{% url 'admin:admin_do_sorting' object.model_type_id %}" class="admin_sorting_url"><i class="fa fa-{% if forloop.first %}sort-desc{% elif forloop.last %}sort-asc{% else %}sort{% endif %}"></i> {{ object }}</a>


### PR DESCRIPTION
When using `djangocms-admin-style` the admin theme is very different then before and it broke the UI

Here is how it looks:

![django-admin-sortable-broken](https://cloud.githubusercontent.com/assets/902381/16085035/6ee5b9e0-3323-11e6-9cc0-5138b4e4bdf4.png)

With my fix it now looks like this:

![django-admin-sortable-fixed](https://cloud.githubusercontent.com/assets/902381/16085069/81eb1620-3323-11e6-8206-8b74c1a0de65.png)


It continue to work and look the same when used without `djangocms-admin-style`.