### PR TITLE
Fix missing icons in Django 1.9

### DIFF
--- a/adminsortable/templates/adminsortable/edit_inline/tabular.html
+++ b/adminsortable/templates/adminsortable/edit_inline/tabular.html
@@ -11,7 +11,7 @@
      {% for field in inline_admin_formset.fields %}
        {% if not field.widget.is_hidden %}
          <th{% if forloop.first %} colspan="2"{% endif %}{% if field.required %} class="required"{% endif %}>{{ field.label|capfirst }}
-         {% if field.help_text %}&nbsp;<img src="{% static "admin/img/icon-unknown.gif" %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />{% endif %}
+         {% if field.help_text %}&nbsp;<img src="{% if django_version.major >= 1 and django_version.minor >= 9 %}{% static "admin/img/icon-unknown.svg" %}{% else %}{% static "admin/img/icon-unknown.gif" %}{% endif %}" class="help help-tooltip" width="10" height="10" alt="({{ field.help_text|striptags }})" title="{{ field.help_text|striptags }}" />{% endif %}
          </th>
        {% endif %}
      {% endfor %}

--- a/sample_project/app/models.py
+++ b/sample_project/app/models.py
@@ -64,8 +64,8 @@ class Credit(SortableMixin):
         ordering = ['order']
 
     project = models.ForeignKey(Project)
-    first_name = models.CharField(max_length=30)
-    last_name = models.CharField(max_length=30)
+    first_name = models.CharField(max_length=30, help_text="Given name")
+    last_name = models.CharField(max_length=30, help_text="Family name")
 
     order = models.PositiveIntegerField(default=0, editable=False)
 
@@ -92,8 +92,8 @@ class Note(SortableMixin):
 @python_2_unicode_compatible
 class NonSortableCredit(models.Model):
     project = models.ForeignKey(Project)
-    first_name = models.CharField(max_length=30)
-    last_name = models.CharField(max_length=30)
+    first_name = models.CharField(max_length=30, help_text="Given name")
+    last_name = models.CharField(max_length=30, help_text="Family name")
 
     def __str__(self):
         return '{0} {1}'.format(self.first_name, self.last_name)


### PR DESCRIPTION
Django 1.9 [replaced](https://docs.djangoproject.com/en/1.9/releases/1.9/#contrib-admin-browser-support) it's admin icons with svgs which causes missing icon errors. Another project had a similar issue: https://github.com/darklow/django-suit/issues/469

I added a version check to the edit_inline/tabular.html template that chooses the svg if django >= 1.9 (similar to how a check above it works).

I also added some help_text to the sample project that will display the problem/fix between 1.8 and 1.9.