### PR TITLE
Enables support for primary keys that are not AutoFields.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ atlassian-*
 .ropeproject
 .codeintel
 __pycache__
+.venv/
+build

--- a/adminsortable/models.py
+++ b/adminsortable/models.py
@@ -1,5 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
+from django.utils import version
 
 from adminsortable.fields import SortableForeignKey
 
@@ -87,7 +88,11 @@ class SortableMixin(models.Model):
             'typecast to an integer.'
 
     def save(self, *args, **kwargs):
-        if not self.pk:
+        major, minor, _, _, _ = version.get_complete_version()
+        needs_default = (self._state.adding
+                         if major == 1 and minor >= 8
+                         else not self.pk)
+        if needs_default:
             try:
                 current_max = self.__class__.objects.aggregate(
                     models.Max(self.order_field_name))[self.order_field_name + '__max'] or 0

--- a/sample_project/app/tests.py
+++ b/sample_project/app/tests.py
@@ -4,6 +4,7 @@ except ImportError:
     import http.client as httplib
 
 import json
+import uuid
 
 from django.contrib.auth.models import User
 from django.db import models
@@ -25,6 +26,14 @@ class TestSortableModel(SortableMixin):
 
     def __unicode__(self):
         return self.title
+
+
+class TestNonAutoFieldModel(SortableMixin):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    order = models.PositiveIntegerField(editable=False, db_index=True)
+
+    class Meta:
+        ordering = ['order']
 
 
 class SortableTestCase(TestCase):
@@ -324,4 +333,8 @@ class SortableTestCase(TestCase):
             }
         ]
         self.assertEqual(notes, expected_notes)
+
+    def test_save_non_auto_field_model(self):
+        model = TestNonAutoFieldModel()
+        model.save()
 


### PR DESCRIPTION
Specially useful when using UUIDs as primary keys.

Example:

```python
from django.db import models
import uuid

class MyModel(SortableMixin):
    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
    order = models.PositiveIntegerField(editable=False, db_index=True)

    class Meta:
        ordering = ['order']
```

That would fail without this fix.