### PR TITLE
Only update the order field when saving objects; omit unnecessary db queries

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -297,7 +297,7 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
 
                 for index in indexes:
                     obj = objects_dict.get(index)
-                    # perform the update iff the order field has changed
+                    # perform the update only if the order field has changed
                     if getattr(obj, order_field_name) != start_index:
                         setattr(obj, order_field_name, start_index)
                         # only update the object's order field

--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -298,7 +298,8 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
                 for index in indexes:
                     obj = objects_dict.get(index)
                     setattr(obj, order_field_name, start_index)
-                    obj.save()
+                    # only update the object's order field
+                    obj.save(update_fields=(order_field_name,))
                     start_index += step
                 response = {'objects_sorted': True}
             except (KeyError, IndexError, klass.DoesNotExist,

--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -297,9 +297,11 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
 
                 for index in indexes:
                     obj = objects_dict.get(index)
-                    setattr(obj, order_field_name, start_index)
-                    # only update the object's order field
-                    obj.save(update_fields=(order_field_name,))
+                    # perform the update iff the order field has changed
+                    if getattr(obj, order_field_name) != start_index:
+                        setattr(obj, order_field_name, start_index)
+                        # only update the object's order field
+                        obj.save(update_fields=(order_field_name,))
                     start_index += step
                 response = {'objects_sorted': True}
             except (KeyError, IndexError, klass.DoesNotExist,


### PR DESCRIPTION
For my use, when reordering, I didn't want to allow the possibility of accidentally overwriting the objects' other fields with stale data.  So, this change uses 'update_fields' to limit the object's save() method to just the order field, so that other fields are not accidentally overwritten with stale data.  For objects with many fields, this should result in faster performance as well, since only the order field is being updated, instead of all the fields.

In addition, it appears that many db queries to set the order are unnecessary.  Therefore, I added a simple check to see whether the just-fetched objects' order fields have changed, and only update those objects.  For large tables, this results in a significant performance improvement.