### PR TITLE
Update to django 1.11

### DIFF
--- a/adminsortable/templatetags/adminsortable_tags.py
+++ b/adminsortable/templatetags/adminsortable_tags.py
@@ -1,5 +1,6 @@
-from django import template
+from django.template.loader import render_to_string
 
+from django import template
 register = template.Library()
 
 
@@ -7,29 +8,25 @@ register = template.Library()
 def render_sortable_objects(context, objects,
         sortable_objects_template='adminsortable/shared/objects.html'):
     context.update({'objects': objects})
-    tmpl = template.loader.get_template(sortable_objects_template)
-    return tmpl.render(context)
+    return render_to_string(sortable_objects_template, context.flatten())
 
 
 @register.simple_tag(takes_context=True)
 def render_nested_sortable_objects(context, objects, group_expression,
         sortable_nested_objects_template='adminsortable/shared/nested_objects.html'):
     context.update({'objects': objects, 'group_expression': group_expression})
-    tmpl = template.loader.get_template(sortable_nested_objects_template)
-    return tmpl.render(context)
+    return render_to_string(sortable_nested_objects_template, context.flatten())
 
 
 @register.simple_tag(takes_context=True)
 def render_list_items(context, list_objects,
         sortable_list_items_template='adminsortable/shared/list_items.html'):
     context.update({'list_objects': list_objects})
-    tmpl = template.loader.get_template(sortable_list_items_template)
-    return tmpl.render(context)
+    return render_to_string(sortable_list_items_template, context.flatten())
 
 
 @register.simple_tag(takes_context=True)
 def render_object_rep(context, obj, forloop,
         sortable_object_rep_template='adminsortable/shared/object_rep.html'):
     context.update({'object': obj, 'forloop': forloop})
-    tmpl = template.loader.get_template(sortable_object_rep_template)
-    return tmpl.render(context)
+    return render_to_string(sortable_object_rep_template, context.flatten())


### PR DESCRIPTION
Fixes `TypeError, context must be a dict rather than RequestContext.`

As seen in https://docs.djangoproject.com/en/1.11/ref/templates/upgrading/#django-template-loader