### PR TITLE
Specify UTF8 encoding for readme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-with open('README.rst') as readme_file:
+with open('README.rst', encoding='utf8') as readme_file:
     README = readme_file.read()
 
 setup(


### PR DESCRIPTION
Installation on Windows is failing due to `”` (also known as: "RIGHT DOUBLE QUOTATION MARK", `0x9D`) appearing in `README.rst`.
The error is `UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 2883: character maps to <undefined>`.