### PR TITLE
add: Allow to define custom ignore list in query params

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -1,4 +1,3 @@
-import json
 from urllib.parse import urlencode
 
 from django.conf import settings
@@ -36,11 +35,17 @@ class SortableAdminBase(object):
 
     after_sorting_js_callback_name = None
 
+    sortable_ignored_params = ()
+
     def get_querystring_filters(self, request):
         filters = {}
 
         for k, v in request.GET.items():
-            if k not in IGNORED_PARAMS and k != PAGE_VAR:
+            if (
+                k not in IGNORED_PARAMS
+                and k != PAGE_VAR
+                and k not in self.sortable_ignored_params
+            ):
                 filters[k] = v
 
         return filters


### PR DESCRIPTION
Not all query params can be model fields for querysets. User can define custom ListFilter and get_queryset on it. Provide option to ignore the params for filters on SortableAdmin.