### PR TITLE
Fix: bug when order value is zero

### DIFF
--- a/adminsortable/__init__.py
+++ b/adminsortable/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (2, 3, 0)
+VERSION = (2, 3, 1)
 DEV_N = None
 
 

--- a/adminsortable/models.py
+++ b/adminsortable/models.py
@@ -89,7 +89,8 @@ class SortableMixin(models.Model):
 
     def save(self, *args, **kwargs):
         needs_default = (self._state.adding if VERSION >= (1, 8) else not self.pk)
-        if not getattr(self, self.order_field_name) and needs_default:
+        order_value = getattr(self, self.order_field_name)
+        if order_value is None and needs_default:
             try:
                 current_max = self.__class__.objects.aggregate(
                     models.Max(self.order_field_name))[self.order_field_name + '__max'] or 0


### PR DESCRIPTION
We don't explicitly **disallow** zero as a value for the ordering field. This assumption comes from the fact that [we allow non-positive integers as values](https://github.com/jazzband/django-admin-sortable/blob/master/adminsortable/models.py#L57), thus, zero is also allowed.

When the value of the ordering field is zero, the `save` method creates a new value, which is not the wanted behavior.
